### PR TITLE
fix missing ":directories t)" in files.md

### DIFF
--- a/files.md
+++ b/files.md
@@ -493,6 +493,7 @@ With `cl-fad:walk-directory`, we can also collect files, not only subdirectories
 (cl-fad:walk-directory "./"
   (lambda (name)
      (format t "~A~%" name))
+   :directories t)
 ~~~
 
 


### PR DESCRIPTION
In `files.md`, there was an example to list all files _and_ directories, using cl-fad:walk-directory.
But there was a missing argument.
Furthermore, there was a missing closing parenthesis.

`cl-fad:walk-directory's documentation` (emphasis' mine):
  Recursively applies the function FN to all files within the
  directory named by the non-wild pathname designator DIRNAME and all of
  its sub-directories.  **FN will only be applied to files** for which the
  function TEST returns a true value.  If **DIRECTORIES is not NIL, FN and
  TEST are applied to directories as well**.  If DIRECTORIES
  is :DEPTH-FIRST, FN will be applied to the directory's contents first.
  If DIRECTORIES is :BREADTH-FIRST and TEST returns NIL, the directory's
  content will be skipped. IF-DOES-NOT-EXIST must be one of :ERROR
  or :IGNORE where :ERROR means that an error will be signaled if the
  directory DIRNAME does not exist.  If FOLLOW-SYMLINKS is T, then your
  callback will receive truenames.  Otherwise you should get the actual
  directory contents, which might include symlinks.  This might not be
  supported on all platforms.  See LIST-DIRECTORY.